### PR TITLE
Add healthcheck route

### DIFF
--- a/apps/backend_fight_web/lib/backend_fight_web/controllers/healthcheck_controller.ex
+++ b/apps/backend_fight_web/lib/backend_fight_web/controllers/healthcheck_controller.ex
@@ -1,0 +1,14 @@
+defmodule BackendFightWeb.HealthcheckController do
+  use BackendFightWeb, :controller
+
+  alias DB.Repo
+  alias Ecto.Adapters.SQL
+
+  def index(conn, _params) do
+    {:ok, _result} = check_database()
+
+    conn |> send_resp(200, "")
+  end
+
+  defp check_database, do: SQL.query(Repo, "select 1", [])
+end

--- a/apps/backend_fight_web/lib/backend_fight_web/router.ex
+++ b/apps/backend_fight_web/lib/backend_fight_web/router.ex
@@ -13,6 +13,10 @@ defmodule BackendFightWeb.Router do
     pipe_through :api
   end
 
+  scope "/", BackendFightWeb do
+    get("/healthcheck", HealthcheckController, :index)
+  end
+
   # Enable LiveDashboard and Swoosh mailbox preview in development
   if Application.compile_env(:backend_fight_web, :dev_routes) do
     # If you want to use the LiveDashboard in production, you should put

--- a/apps/backend_fight_web/test/backend_fight_web/controllers/healthcheck_controller_test.exs
+++ b/apps/backend_fight_web/test/backend_fight_web/controllers/healthcheck_controller_test.exs
@@ -1,0 +1,11 @@
+defmodule BackendFightWeb.HealthcheckControllerTest do
+  use BackendFightWeb.ConnCase
+
+  test "GET /healthcheck, when everything happens as it should, it is expected to return 200 without a body", %{
+    conn: conn
+  } do
+    conn = conn |> get("/healthcheck")
+
+    assert "" = response(conn, 200)
+  end
+end


### PR DESCRIPTION
## Alterações:

## Objetivo do PR:
<!-- Deixar claro, de forma textual, a meta a ser alcançada. -->

Adiciona rota de _healthcheck_.

```
A ideia aqui seria apenas testar o gatilho com cache.
```

## Este PR introduz uma alteração que pode quebrar?
<!-- Embora toda alteração possa quebrar uma aplicação, algumas possuem "risco" maior que outras, elucidar aqui. -->

**Não**.

## Outras informações:
<!-- Não obrigatório. Ex: imagens, links, tarefa etc. -->

**Contrato**

Sucesso:

```bash
 curl -v <PROTOCOL>://<HOST>:<PORT>/healthcheck
```

Retorno **HTTP_STATUS_CODE: 200**.
